### PR TITLE
pwd からの pbcopy を一発でできるようにする

### DIFF
--- a/wdcp
+++ b/wdcp
@@ -1,0 +1,2 @@
+#!/bin/bash
+pwd | pbcopy


### PR DESCRIPTION
mac で下記のコマンドをかなりの回数実行するのでスクリプトにした

```bash
$ pwd | pbcopy
```